### PR TITLE
Add new NH statistic class CircllhistStatistic and SinkableCircllhistStatistic

### DIFF
--- a/source/common/BUILD
+++ b/source/common/BUILD
@@ -109,7 +109,7 @@ envoy_cc_library(
         "@envoy//source/common/http:utility_lib_with_external_headers",
         "@envoy//source/common/network:utility_lib_with_external_headers",
         "@envoy//source/common/protobuf:utility_lib_with_external_headers",
-        "@envoy//source/common/stats:stats_lib_with_external_headers",
+        "@envoy//source/common/stats:histogram_lib_with_external_headers",
         "@envoy//source/exe:envoy_common_lib_with_external_headers",
         "@envoy//source/server/config_validation:server_lib_with_external_headers",
     ],

--- a/source/common/statistic_impl.cc
+++ b/source/common/statistic_impl.cc
@@ -235,7 +235,7 @@ nighthawk::client::Statistic HdrStatistic::toProto(SerializationDomain domain) c
 
   return proto;
 }
-  
+
 StatisticPtr CircllhistStatistic::combine(const Statistic& statistic) const {
   auto combined = std::make_unique<CircllhistStatistic>();
   const auto& b = dynamic_cast<const CircllhistStatistic&>(statistic);
@@ -250,7 +250,8 @@ StatisticPtr CircllhistStatistic::combine(const Statistic& statistic) const {
 
 nighthawk::client::Statistic CircllhistStatistic::toProto(SerializationDomain domain) const {
   nighthawk::client::Statistic proto = StatisticImpl::toProto(domain);
-  if (count() == 0) return proto;
+  if (count() == 0)
+    return proto;
 
   std::vector<double> quantiles{0, 0.25, 0.5, 0.75, 0.90, 0.95, 0.99, 0.995, 0.999, 1};
   std::vector<double> computed_quantiles(quantiles.size(), 0.0);
@@ -258,7 +259,8 @@ nighthawk::client::Statistic CircllhistStatistic::toProto(SerializationDomain do
   for (size_t i = 0; i < quantiles.size(); i++) {
     nighthawk::client::Percentile* percentile = proto.add_percentiles();
     if (domain == Statistic::SerializationDomain::DURATION) {
-      setDurationFromNanos(*percentile->mutable_duration(), static_cast<int64_t>(computed_quantiles[i]));
+      setDurationFromNanos(*percentile->mutable_duration(),
+                           static_cast<int64_t>(computed_quantiles[i]));
     } else {
       percentile->set_raw_value(computed_quantiles[i]);
     }

--- a/source/common/statistic_impl.cc
+++ b/source/common/statistic_impl.cc
@@ -235,5 +235,37 @@ nighthawk::client::Statistic HdrStatistic::toProto(SerializationDomain domain) c
 
   return proto;
 }
+  
+StatisticPtr CircllhistStatistic::combine(const Statistic& statistic) const {
+  auto combined = std::make_unique<CircllhistStatistic>();
+  const auto& b = dynamic_cast<const CircllhistStatistic&>(statistic);
+  hist_accumulate(combined->histogram_, &this->histogram_, 1);
+  hist_accumulate(combined->histogram_, &b.histogram_, 1);
+
+  combined->min_ = std::min(this->min(), b.min());
+  combined->max_ = std::max(this->max(), b.max());
+  combined->count_ = this->count() + b.count();
+  return combined;
+}
+
+nighthawk::client::Statistic CircllhistStatistic::toProto(SerializationDomain domain) const {
+  nighthawk::client::Statistic proto = StatisticImpl::toProto(domain);
+  if (count() == 0) return proto;
+
+  std::vector<double> quantiles{0, 0.25, 0.5, 0.75, 0.90, 0.95, 0.99, 0.995, 0.999, 1};
+  std::vector<double> computed_quantiles(quantiles.size(), 0.0);
+  hist_approx_quantile(histogram_, quantiles.data(), quantiles.size(), computed_quantiles.data());
+  for (int i = 0; i < quantiles.size(); i++) {
+    nighthawk::client::Percentile* percentile = proto.add_percentiles();
+    if (domain == Statistic::SerializationDomain::DURATION) {
+      setDurationFromNanos(*percentile->mutable_duration(), static_cast<int64_t>(computed_quantiles[i]));
+    } else {
+      percentile->set_raw_value(computed_quantiles[i]);
+    }
+    percentile->set_percentile(quantiles[i]);
+  }
+
+  return proto;
+}
 
 } // namespace Nighthawk

--- a/source/common/statistic_impl.cc
+++ b/source/common/statistic_impl.cc
@@ -263,6 +263,7 @@ nighthawk::client::Statistic CircllhistStatistic::toProto(SerializationDomain do
       percentile->set_raw_value(computed_quantiles[i]);
     }
     percentile->set_percentile(quantiles[i]);
+    percentile->set_count(hist_approx_count_below(histogram_, computed_quantiles[i]));
   }
 
   return proto;

--- a/source/common/statistic_impl.cc
+++ b/source/common/statistic_impl.cc
@@ -255,7 +255,7 @@ nighthawk::client::Statistic CircllhistStatistic::toProto(SerializationDomain do
   std::vector<double> quantiles{0, 0.25, 0.5, 0.75, 0.90, 0.95, 0.99, 0.995, 0.999, 1};
   std::vector<double> computed_quantiles(quantiles.size(), 0.0);
   hist_approx_quantile(histogram_, quantiles.data(), quantiles.size(), computed_quantiles.data());
-  for (int i = 0; i < quantiles.size(); i++) {
+  for (size_t i = 0; i < quantiles.size(); i++) {
     nighthawk::client::Percentile* percentile = proto.add_percentiles();
     if (domain == Statistic::SerializationDomain::DURATION) {
       setDurationFromNanos(*percentile->mutable_duration(), static_cast<int64_t>(computed_quantiles[i]));

--- a/source/common/statistic_impl.h
+++ b/source/common/statistic_impl.h
@@ -150,14 +150,15 @@ private:
   static const int SignificantDigits;
   struct hdr_histogram* histogram_;
 };
-  
+
 /**
  * CircllhistStatistic uses Circllhist under the hood to compute statistics.
- * Circllhist is used in the implementation of Envoy Histograms, compared to HdrHistogram it trades precision for fast performance in merge and insertion.
- * For more info, please see https://github.com/circonus-labs/libcircllhist
+ * Circllhist is used in the implementation of Envoy Histograms, compared to HdrHistogram it trades
+ * precision for fast performance in merge and insertion. For more info, please see
+ * https://github.com/circonus-labs/libcircllhist
  */
 class CircllhistStatistic : public StatisticImpl {
- public:
+public:
   CircllhistStatistic() {
     histogram_ = hist_alloc();
     ASSERT(histogram_ != nullptr);
@@ -170,7 +171,9 @@ class CircllhistStatistic : public StatisticImpl {
   }
   double mean() const override { return hist_approx_mean(histogram_); }
   double pvariance() const override { return pstdev() * pstdev(); }
-  double pstdev() const override { return count() == 0 ? std::nan("") : hist_approx_stddev(histogram_); }
+  double pstdev() const override {
+    return count() == 0 ? std::nan("") : hist_approx_stddev(histogram_);
+  }
   StatisticPtr combine(const Statistic& statistic) const override;
   uint64_t significantDigits() const override { return 1; }
   StatisticPtr createNewInstanceOfSameType() const override {
@@ -178,20 +181,26 @@ class CircllhistStatistic : public StatisticImpl {
   }
   nighthawk::client::Statistic toProto(SerializationDomain domain) const override;
 
- private:
+private:
   histogram_t* histogram_;
 };
 
 /**
- * In order to be able to flush histogram value to downstream Envoy stats Sinks, Per worker SinkableCircllhistStatistic takes the
- * Scope reference in the constructor and wraps the Envoy::Stats::Histogram interface.
+ * In order to be able to flush histogram value to downstream Envoy stats Sinks, Per worker
+ * SinkableCircllhistStatistic takes the Scope reference in the constructor and wraps the
+ * Envoy::Stats::Histogram interface.
  */
 class SinkableCircllhistStatistic : public CircllhistStatistic,
                                     public Envoy::Stats::HistogramImplHelper {
- public:
-  // Calling HistogramImplHelper(SymbolTable& symbol_table) constructor to construct an empty MetricImpl. This is to bypass the complicated logic of setting up SymbolTable/StatName in Envoy. Instead, SinkableCircllhistStatistic overrides name() and tagExtractedName() method to return Nighthawk::Statistic::id().
-  SinkableCircllhistStatistic(Envoy::Stats::Scope& scope, const absl::optional<int> worker_id = absl::nullopt)
-      : CircllhistStatistic(), Envoy::Stats::HistogramImplHelper(scope.symbolTable()), scope_(scope), worker_id_(worker_id) {}
+public:
+  // Calling HistogramImplHelper(SymbolTable& symbol_table) constructor to construct an empty
+  // MetricImpl. This is to bypass the complicated logic of setting up SymbolTable/StatName in
+  // Envoy. Instead, SinkableCircllhistStatistic overrides name() and tagExtractedName() method to
+  // return Nighthawk::Statistic::id().
+  SinkableCircllhistStatistic(Envoy::Stats::Scope& scope,
+                              const absl::optional<int> worker_id = absl::nullopt)
+      : CircllhistStatistic(), Envoy::Stats::HistogramImplHelper(scope.symbolTable()),
+        scope_(scope), worker_id_(worker_id) {}
 
   ~SinkableCircllhistStatistic() override {
     // We must explicitly free the StatName here in order to supply the
@@ -202,23 +211,23 @@ class SinkableCircllhistStatistic : public CircllhistStatistic,
   // Envoy::Stats::Histogram
   void recordValue(uint64_t value) override {
     addValue(value);
-    // Currently in Envoy Scope implementation, deliverHistogramToSinks() will flush the histogram value directly to stats Sinks.
+    // Currently in Envoy Scope implementation, deliverHistogramToSinks() will flush the histogram
+    // value directly to stats Sinks.
     scope_.deliverHistogramToSinks(*this, value);
   }
   Envoy::Stats::Histogram::Unit unit() const override {
     return Envoy::Stats::Histogram::Unit::Unspecified;
   };
   bool used() const override { return count() > 0; }
-  Envoy::Stats::SymbolTable& symbolTable() override {
-    return scope_.symbolTable();
-  }
-  // Overriding name() and tagExtractedName() method in Envoy::Stats::MetricImpl to return Statistic::id().
+  Envoy::Stats::SymbolTable& symbolTable() override { return scope_.symbolTable(); }
+  // Overriding name() and tagExtractedName() method in Envoy::Stats::MetricImpl to return
+  // Statistic::id().
   std::string name() const override { return id(); }
   std::string tagExtractedName() const override { return id(); }
 
   const absl::optional<int> worker_id() { return worker_id_; }
 
- private:
+private:
   // This is used for delivering the histogram data to sinks.
   Envoy::Stats::Scope& scope_;
   // worker_id can be used in downstream stats Sinks as the stats tag.

--- a/source/common/statistic_impl.h
+++ b/source/common/statistic_impl.h
@@ -7,6 +7,7 @@
 
 #include "external/dep_hdrhistogram_c/src/hdr_histogram.h"
 #include "external/envoy/source/common/common/logger.h"
+#include "external/envoy/source/common/stats/histogram_impl.h"
 
 #include "common/frequency.h"
 
@@ -148,6 +149,80 @@ public:
 private:
   static const int SignificantDigits;
   struct hdr_histogram* histogram_;
+};
+  
+/**
+ * CircllhistStatistic uses Circllhist under the hood to compute statistics.
+ * Circllhist is used in the implementation of Envoy Histograms, compared to HdrHistogram it trades precision for fast performance in merge and insertion.
+ * For more info, please see https://github.com/circonus-labs/libcircllhist
+ */
+class CircllhistStatistic : public StatisticImpl {
+ public:
+  CircllhistStatistic() {
+    histogram_ = hist_alloc();
+    ASSERT(histogram_ != nullptr);
+  }
+  ~CircllhistStatistic() override { hist_free(histogram_); }
+
+  void addValue(uint64_t value) override {
+    hist_insert_intscale(histogram_, value, 0, 1);
+    StatisticImpl::addValue(value);
+  }
+  double mean() const override { return hist_approx_mean(histogram_); }
+  double pvariance() const override { return pstdev() * pstdev(); }
+  double pstdev() const override { return count() == 0 ? std::nan("") : hist_approx_stddev(histogram_); }
+  StatisticPtr combine(const Statistic& statistic) const override;
+  uint64_t significantDigits() const override { return 1; }
+  StatisticPtr createNewInstanceOfSameType() const override {
+    return std::make_unique<CircllhistStatistic>();
+  }
+  nighthawk::client::Statistic toProto(SerializationDomain domain) const override;
+
+ private:
+  histogram_t* histogram_;
+};
+
+/**
+ * In order to be able to flush histogram value to downstream Envoy stats Sinks, Per worker SinkableCircllhistStatistic takes the
+ * Scope reference in the constructor and wraps the Envoy::Stats::Histogram interface.
+ */
+class SinkableCircllhistStatistic : public CircllhistStatistic,
+                                    public Envoy::Stats::HistogramImplHelper {
+ public:
+  // Calling HistogramImplHelper(SymbolTable& symbol_table) constructor to construct an empty MetricImpl. This is to bypass the complicated logic of setting up SymbolTable/StatName in Envoy. Instead, SinkableCircllhistStatistic overrides name() and tagExtractedName() method to return Nighthawk::Statistic::id().
+  SinkableCircllhistStatistic(Envoy::Stats::Scope& scope, const absl::optional<int> worker_id = absl::nullopt)
+      : CircllhistStatistic(), Envoy::Stats::HistogramImplHelper(scope.symbolTable()), scope_(scope), worker_id_(worker_id) {}
+
+  ~SinkableCircllhistStatistic() override {
+    // We must explicitly free the StatName here in order to supply the
+    // SymbolTable reference.
+    MetricImpl::clear(symbolTable());
+  }
+
+  // Envoy::Stats::Histogram
+  void recordValue(uint64_t value) override {
+    addValue(value);
+    // Currently in Envoy Scope implementation, deliverHistogramToSinks() will flush the histogram value directly to stats Sinks.
+    scope_.deliverHistogramToSinks(*this, value);
+  }
+  Envoy::Stats::Histogram::Unit unit() const override {
+    return Envoy::Stats::Histogram::Unit::Unspecified;
+  };
+  bool used() const override { return count() > 0; }
+  Envoy::Stats::SymbolTable& symbolTable() override {
+    return scope_.symbolTable();
+  }
+  // Overriding name() and tagExtractedName() method in Envoy::Stats::MetricImpl to return Statistic::id().
+  std::string name() const override { return id(); }
+  std::string tagExtractedName() const override { return id(); }
+
+  const absl::optional<int> worker_id() { return worker_id_; }
+
+ private:
+  // This is used for delivering the histogram data to sinks.
+  Envoy::Stats::Scope& scope_;
+  // worker_id can be used in downstream stats Sinks as the stats tag.
+  absl::optional<int> worker_id_;
 };
 
 } // namespace Nighthawk

--- a/test/BUILD
+++ b/test/BUILD
@@ -195,7 +195,10 @@ envoy_cc_test(
 envoy_cc_test(
     name = "statistic_test",
     srcs = ["statistic_test.cc"],
-    data = ["test_data/hdr_proto_json.gold", "test_data/circllhist_proto_json.gold"],
+    data = [
+        "test_data/circllhist_proto_json.gold",
+        "test_data/hdr_proto_json.gold",
+    ],
     repository = "@envoy",
     deps = [
         "//source/common:nighthawk_common_lib",

--- a/test/BUILD
+++ b/test/BUILD
@@ -202,6 +202,7 @@ envoy_cc_test(
         "//test/test_common:environment_lib",
         "@envoy//source/common/protobuf:utility_lib_with_external_headers",
         "@envoy//source/common/stats:isolated_store_lib_with_external_headers",
+        "@envoy//test/mocks/stats:stats_mocks",
     ],
 )
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -195,7 +195,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "statistic_test",
     srcs = ["statistic_test.cc"],
-    data = ["test_data/hdr_proto_json.gold"],
+    data = ["test_data/hdr_proto_json.gold", "test_data/circllhist_proto_json.gold"],
     repository = "@envoy",
     deps = [
         "//source/common:nighthawk_common_lib",

--- a/test/statistic_test.cc
+++ b/test/statistic_test.cc
@@ -314,7 +314,7 @@ TEST(StatisticTest, CircllhistStatisticPercentilesProto) {
 
   Envoy::MessageUtil util;
   util.loadFromJson(Envoy::Filesystem::fileSystemForTest().fileReadToEnd(
-                        TestEnvironment::runfilesPath("test/test_data/hdr_proto_json.gold")),
+                        TestEnvironment::runfilesPath("test/test_data/circllhist_proto_json.gold")),
                     parsed_json_proto, Envoy::ProtobufMessage::getStrictValidationVisitor());
   // Instead of comparing proto's, we perform a string-based comparison, because that emits a
   // helpful diff when this fails.

--- a/test/statistic_test.cc
+++ b/test/statistic_test.cc
@@ -314,7 +314,7 @@ TEST(StatisticTest, CircllhistStatisticPercentilesProto) {
 
   Envoy::MessageUtil util;
   util.loadFromJson(Envoy::Filesystem::fileSystemForTest().fileReadToEnd(
-                        TestEnvironment::runfilesPath("nighthawk/test/test_data/hdr_proto_json.gold")),
+                        TestEnvironment::runfilesPath("test/test_data/hdr_proto_json.gold")),
                     parsed_json_proto, Envoy::ProtobufMessage::getStrictValidationVisitor());
   // Instead of comparing proto's, we perform a string-based comparison, because that emits a
   // helpful diff when this fails.

--- a/test/statistic_test.cc
+++ b/test/statistic_test.cc
@@ -2,10 +2,12 @@
 
 #include <chrono>
 #include <random>
+#include <string>
 #include <typeinfo> // std::bad_cast
 
 #include "external/envoy/source/common/protobuf/utility.h"
 #include "external/envoy/source/common/stats/isolated_store_impl.h"
+#include "external/envoy/test/mocks/stats/mocks.h"
 #include "external/envoy/test/test_common/file_system_for_test.h"
 #include "external/envoy/test/test_common/utility.h"
 
@@ -20,7 +22,7 @@ using namespace testing;
 
 namespace Nighthawk {
 
-using MyTypes = Types<SimpleStatistic, InMemoryStatistic, HdrStatistic, StreamingStatistic>;
+using MyTypes = Types<SimpleStatistic, InMemoryStatistic, HdrStatistic, StreamingStatistic, CircllhistStatistic>;
 
 template <typename T> class TypedStatisticTest : public Test {};
 
@@ -116,15 +118,15 @@ TYPED_TEST(TypedStatisticTest, SingleAndDoubleValue) {
 
   a.addValue(1);
   EXPECT_EQ(1, a.count());
-  EXPECT_DOUBLE_EQ(1, a.mean());
+  Helper::expectNear(1.0, a.mean(), a.significantDigits());
   EXPECT_DOUBLE_EQ(0, a.pvariance());
   EXPECT_DOUBLE_EQ(0, a.pstdev());
 
   a.addValue(2);
   EXPECT_EQ(2, a.count());
-  EXPECT_DOUBLE_EQ(1.5, a.mean());
-  EXPECT_DOUBLE_EQ(0.25, a.pvariance());
-  EXPECT_DOUBLE_EQ(0.5, a.pstdev());
+  Helper::expectNear(1.5, a.mean(), a.significantDigits());
+  Helper::expectNear(0.25, a.pvariance(), a.significantDigits());
+  Helper::expectNear(0.5, a.pstdev(), a.significantDigits());
 }
 
 TYPED_TEST(TypedStatisticTest, CatastrophicalCancellation) {
@@ -268,6 +270,19 @@ TEST(StatisticTest, StreamingStatProtoOutputLargeValues) {
 
   EXPECT_EQ(proto.pstdev().nanos(), 0);
 }
+  
+TEST(StatisticTest, CircllhistStatisticProtoOutputLargeValues) {
+  CircllhistStatistic a;
+  uint64_t value = 100ul + 0xFFFFFFFF;
+  a.addValue(value);
+  a.addValue(value);
+  const nighthawk::client::Statistic proto = a.toProto(Statistic::SerializationDomain::DURATION);
+
+  EXPECT_EQ(proto.count(), 2);
+  Helper::expectNear(((1.0 * proto.mean().seconds() * 1000 * 1000 * 1000) + proto.mean().nanos()),
+                     value, a.significantDigits());
+  EXPECT_EQ(proto.pstdev().nanos(), 0);
+}
 
 TEST(StatisticTest, HdrStatisticPercentilesProto) {
   nighthawk::client::Statistic parsed_json_proto;
@@ -288,17 +303,40 @@ TEST(StatisticTest, HdrStatisticPercentilesProto) {
   const std::string golden_json = util.getJsonStringFromMessage(parsed_json_proto, true, true);
   EXPECT_EQ(json, golden_json);
 }
+  
+TEST(StatisticTest, CircllhistStatisticPercentilesProto) {
+  nighthawk::client::Statistic parsed_json_proto;
+  CircllhistStatistic statistic;
+
+  for (int i = 1; i <= 10; i++) {
+    statistic.addValue(i);
+  }
+
+  Envoy::MessageUtil util;
+  util.loadFromJson(Envoy::Filesystem::fileSystemForTest().fileReadToEnd(
+                        TestEnvironment::runfilesPath("nighthawk/test/test_data/hdr_proto_json.gold")),
+                    parsed_json_proto, Envoy::ProtobufMessage::getStrictValidationVisitor());
+  // Instead of comparing proto's, we perform a string-based comparison, because that emits a
+  // helpful diff when this fails.
+  const std::string json = util.getJsonStringFromMessage(
+      statistic.toProto(Statistic::SerializationDomain::DURATION), true, true);
+  const std::string golden_json = util.getJsonStringFromMessage(parsed_json_proto, true, true);
+  EXPECT_EQ(json, golden_json);
+}
 
 TEST(StatisticTest, CombineAcrossTypesFails) {
   HdrStatistic a;
   InMemoryStatistic b;
   StreamingStatistic c;
+  CircllhistStatistic d;
   EXPECT_THROW(a.combine(b), std::bad_cast);
   EXPECT_THROW(a.combine(c), std::bad_cast);
   EXPECT_THROW(b.combine(a), std::bad_cast);
   EXPECT_THROW(b.combine(c), std::bad_cast);
   EXPECT_THROW(c.combine(a), std::bad_cast);
   EXPECT_THROW(c.combine(b), std::bad_cast);
+  EXPECT_THROW(c.combine(d), std::bad_cast);
+  EXPECT_THROW(d.combine(a), std::bad_cast);
 }
 
 TEST(StatisticTest, IdFieldWorks) {
@@ -326,6 +364,36 @@ TEST(StatisticTest, NullStatistic) {
   EXPECT_NE(nullptr, stat.combine(stat));
   EXPECT_EQ(0, stat.significantDigits());
   EXPECT_NE(nullptr, stat.createNewInstanceOfSameType());
+}
+  
+TEST(StatisticTest, EmptySinkableCircllhistStatistic) {
+  Envoy::Stats::MockIsolatedStatsStore mock_store;
+  SinkableCircllhistStatistic stat(mock_store);
+  EXPECT_EQ(Envoy::Stats::Histogram::Unit::Unspecified, stat.unit());
+  EXPECT_FALSE(stat.used());
+  EXPECT_EQ("", stat.name());
+  EXPECT_EQ("", stat.tagExtractedName());
+  EXPECT_EQ(absl::nullopt, stat.worker_id());
+}
+
+TEST(StatisticTest, SimpleSinkableCircllhistStatistic) {
+  Envoy::Stats::MockIsolatedStatsStore mock_store;
+  const int worker_id = 0;
+  SinkableCircllhistStatistic stat(mock_store, worker_id);
+
+  const uint64_t sample_value = 123;
+  const std::string stat_name = "stat_name";
+
+  EXPECT_CALL(mock_store, deliverHistogramToSinks(_, sample_value)).Times(1);
+  stat.recordValue(sample_value);
+
+  stat.setId(stat_name);
+  EXPECT_EQ(Envoy::Stats::Histogram::Unit::Unspecified, stat.unit());
+  EXPECT_TRUE(stat.used());
+  EXPECT_EQ(stat_name, stat.name());
+  EXPECT_EQ(stat_name, stat.tagExtractedName());
+  EXPECT_TRUE(stat.worker_id().has_value());
+  EXPECT_EQ(worker_id, stat.worker_id().value());
 }
 
 } // namespace Nighthawk

--- a/test/statistic_test.cc
+++ b/test/statistic_test.cc
@@ -22,7 +22,8 @@ using namespace testing;
 
 namespace Nighthawk {
 
-using MyTypes = Types<SimpleStatistic, InMemoryStatistic, HdrStatistic, StreamingStatistic, CircllhistStatistic>;
+using MyTypes = Types<SimpleStatistic, InMemoryStatistic, HdrStatistic, StreamingStatistic,
+                      CircllhistStatistic>;
 
 template <typename T> class TypedStatisticTest : public Test {};
 
@@ -270,7 +271,7 @@ TEST(StatisticTest, StreamingStatProtoOutputLargeValues) {
 
   EXPECT_EQ(proto.pstdev().nanos(), 0);
 }
-  
+
 TEST(StatisticTest, CircllhistStatisticProtoOutputLargeValues) {
   CircllhistStatistic a;
   uint64_t value = 100ul + 0xFFFFFFFF;
@@ -303,7 +304,7 @@ TEST(StatisticTest, HdrStatisticPercentilesProto) {
   const std::string golden_json = util.getJsonStringFromMessage(parsed_json_proto, true, true);
   EXPECT_EQ(json, golden_json);
 }
-  
+
 TEST(StatisticTest, CircllhistStatisticPercentilesProto) {
   nighthawk::client::Statistic parsed_json_proto;
   CircllhistStatistic statistic;
@@ -365,7 +366,7 @@ TEST(StatisticTest, NullStatistic) {
   EXPECT_EQ(0, stat.significantDigits());
   EXPECT_NE(nullptr, stat.createNewInstanceOfSameType());
 }
-  
+
 TEST(StatisticTest, EmptySinkableCircllhistStatistic) {
   Envoy::Stats::MockIsolatedStatsStore mock_store;
   SinkableCircllhistStatistic stat(mock_store);

--- a/test/test_data/circllhist_proto_json.gold
+++ b/test/test_data/circllhist_proto_json.gold
@@ -1,0 +1,60 @@
+{
+ "count": "10",
+ "id": "",
+ "percentiles": [
+  {
+   "percentile": 0,
+   "count": "1",
+   "duration": "0.000000001s"
+  },
+  {
+   "percentile": 0.25,
+   "count": "3",
+   "duration": "0.000000003s"
+  },
+  {
+   "percentile": 0.5,
+   "count": "5",
+   "duration": "0.000000005s"
+  },
+  {
+   "percentile": 0.75,
+   "count": "8",
+   "duration": "0.000000008s"
+  },
+  {
+   "percentile": 0.9,
+   "count": "9",
+   "duration": "0.000000009s"
+  },
+  {
+   "percentile": 0.95,
+   "count": "10",
+   "duration": "0.000000010s"
+  },
+  {
+   "percentile": 0.99,
+   "count": "10",
+   "duration": "0.000000010s"
+  },
+  {
+   "percentile": 0.995,
+   "count": "10",
+   "duration": "0.000000010s"
+  },
+  {
+   "percentile": 0.999,
+   "count": "10",
+   "duration": "0.000000010s"
+  },
+  {
+   "percentile": 1,
+   "count": "10",
+   "duration": "0.000000010s"
+  }
+ ],
+ "mean": "0.000000006s",
+ "pstdev": "0.000000003s",
+ "min": "0.000000001s",
+ "max": "0.000000010s"
+}

--- a/test/test_data/circllhist_proto_json.gold
+++ b/test/test_data/circllhist_proto_json.gold
@@ -4,12 +4,12 @@
  "percentiles": [
   {
    "percentile": 0,
-   "count": "1",
+   "count": "0",
    "duration": "0.000000001s"
   },
   {
    "percentile": 0.25,
-   "count": "3",
+   "count": "2",
    "duration": "0.000000003s"
   },
   {
@@ -19,7 +19,7 @@
   },
   {
    "percentile": 0.75,
-   "count": "8",
+   "count": "7",
    "duration": "0.000000008s"
   },
   {
@@ -29,28 +29,28 @@
   },
   {
    "percentile": 0.95,
-   "count": "10",
+   "count": "9",
    "duration": "0.000000010s"
   },
   {
    "percentile": 0.99,
-   "count": "10",
+   "count": "9",
    "duration": "0.000000010s"
   },
   {
    "percentile": 0.995,
-   "count": "10",
+   "count": "9",
    "duration": "0.000000010s"
   },
   {
    "percentile": 0.999,
-   "count": "10",
+   "count": "9",
    "duration": "0.000000010s"
   },
   {
    "percentile": 1,
    "count": "10",
-   "duration": "0.000000010s"
+   "duration": "0.000000011s"
   }
  ],
  "mean": "0.000000006s",


### PR DESCRIPTION
Add new NH statistic class CircllhistStatistic and SinkableCircllhistStatistic.

CircllhistStatistic uses Circllhist under the hood to compute statistics where Circllhist is used in the implementation of Envoy Histograms, compared to HdrHistogram it trades precision for fast performance in merge and insertion according to https://github.com/envoyproxy/nighthawk/issues/115.

SinkableCircllhistStatistic wraps the Envoy::Stats::Histogram interface and is used to flush histogram value to downstream Envoy stats Sinks.

#344

Testing: unit tests